### PR TITLE
Fix tf2_eigen include to use .hpp

### DIFF
--- a/vdb_mapping_ros2/include/vdb_mapping_ros2/VDBMappingROS2.hpp
+++ b/vdb_mapping_ros2/include/vdb_mapping_ros2/VDBMappingROS2.hpp
@@ -29,7 +29,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <tf2/exceptions.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 


### PR DESCRIPTION
Fix warning: warning: #warning This header is obsolete, please include tf2_eigen/tf2_eigen.hpp